### PR TITLE
Allow to display images as site_name

### DIFF
--- a/src/Resources/views/Admin/login.html.twig
+++ b/src/Resources/views/Admin/login.html.twig
@@ -1,7 +1,7 @@
 {% extends '@WandiEasyAdminPlus/layout.html.twig' %}
 
 {% block page_title %}
-    {{ config.site_name }} - {{ 'login.title'|trans({}, 'EasyAdminPlusBundle') }}
+    {{ config.site_name|striptags }}{% if config.site_name|striptags is not empty %} - {% endif %}{{ 'login.title'|trans({}, 'EasyAdminPlusBundle') }}
 {% endblock %}
 
 {% block body %}
@@ -11,7 +11,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-md-4 col-md-offset-4">
-                    <h1 class="page-title">{{ config.site_name }}</h1>
+                    <h1 class="page-title">{{ config.site_name|raw }}</h1>
                     <div class="well">
                         {% if error %}
                             <div class="alert alert-danger" role="alert">
@@ -47,3 +47,4 @@
     </div>
     </body>
 {% endblock %}
+

--- a/src/Resources/views/Admin/login.html.twig
+++ b/src/Resources/views/Admin/login.html.twig
@@ -47,4 +47,3 @@
     </div>
     </body>
 {% endblock %}
-


### PR DESCRIPTION
In easyadmin manual is example where they shows how to put logo or other html tags as site_name https://symfony.com/doc/current/bundles/EasyAdminBundle/book/basic-configuration.html, in this PR I've updated login template for handling custom tags.